### PR TITLE
Only add a section page when header is not empty

### DIFF
--- a/internal/gig/gig_test.go
+++ b/internal/gig/gig_test.go
@@ -26,7 +26,11 @@ func TestNew(t *testing.T) {
 				Name: "MyBand @ Grand Ole Opry",
 				Sections: []Section{
 					{
-						Header:     []byte("# Set 1\n\nSay Hello"),
+						Header:     []byte{},
+						SongTitles: []string{"Preamble"},
+					},
+					{
+						Header:     []byte("\n\n# Set 1\n\nSay Hello"),
 						SongTitles: []string{"Frankie and Johnnie", "On the Alamo", "Her Song"},
 					},
 					{

--- a/internal/repertoire/repertoire_test.go
+++ b/internal/repertoire/repertoire_test.go
@@ -28,6 +28,7 @@ func TestNew(t *testing.T) {
 					{Title: "On the Alamo"},
 					{Title: "Frankie and Johnnie"},
 					{Title: "Nowhere to go"},
+					{Title: "Preamble"},
 					{Title: "Her Song"},
 				},
 			},

--- a/internal/sheet/sheet.go
+++ b/internal/sheet/sheet.go
@@ -113,13 +113,15 @@ func ForGig(band config.Band, gig gig.Gig) error {
 	sh := sectionHeaders{}
 	for _, section := range gig.Sections {
 		h := section.HeaderText()
-		sh.add(h)
-		html, err := section.HeaderHTML()
-		if err != nil {
-			return err
+		if h != "" {
+			sh.add(h)
+			html, err := section.HeaderHTML()
+			if err != nil {
+				return err
+			}
+			header := Sheet{band: band, name: sh.filename(h), content: html}
+			sheets = append(sheets, header)
 		}
-		header := Sheet{band: band, name: sh.filename(h), content: html}
-		sheets = append(sheets, header)
 		for _, title := range section.SongTitles {
 			song := Sheet{band: band, name: title, content: title}
 			sheets = append(sheets, song)

--- a/test/Repertoire/Band/Gigs/Grand Ole Opry.md
+++ b/test/Repertoire/Band/Gigs/Grand Ole Opry.md
@@ -1,3 +1,5 @@
+* Preamble
+
 # Set 1
 
 Say Hello
@@ -7,4 +9,5 @@ Say Hello
 * Her Song
 
 # Encore
+
 * Nowhere To Go

--- a/test/Repertoire/Band/Repertoire.md
+++ b/test/Repertoire/Band/Repertoire.md
@@ -4,5 +4,5 @@
 | On the Alamo          | 1922 | Lyrics: Gus Kahn  | Isham Jones      | Chris Lae      | 3m 2s    |
 | Frankie and Johnnie   | 1904 |                   | Hughie Cannon    | Chris Lae      | 2m 30s   |
 | Nowhere to go         | 2024 | Instrumental      | Chris Lae        | Chris Lae      | 7m       |
-| [[Her Song]]              | 2024 |                   | Unknown          | Chris Lae      | 55s      |
-
+| Preamble              | 2024 | Get started       | Chris Lae        | Chris Lae      | 1m       |
+| [[Her Song]]          | 2024 |                   | Unknown          | Chris Lae      | 55s      |


### PR DESCRIPTION
in case the section header is empty (e.g. in case of the first section), don't create an empty header page