### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,18 +11,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
     - name: Build
       run: make build
 
-    - uses: golangci/golangci-lint-action@v7
-      with:
-        version: v2.11.4
+    - uses: golangci/golangci-lint-action@v9
 
     - name: Unit Test
       run: make test

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,21 +13,21 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
-    - uses: docker/login-action@v3
+    - uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: goreleaser/goreleaser-action@v6
+    - uses: goreleaser/goreleaser-action@v7
       with:
         version: '~> v2'
         args: release --clean


### PR DESCRIPTION
Update all GitHub Actions to versions that support Node.js 24, ahead of the June 2nd 2026 deprecation of Node.js 20 runners.

- `actions/checkout` v4 → v6
- `actions/setup-go` v5 → v6
- `golangci/golangci-lint-action` v7 → v9
- `goreleaser/goreleaser-action` v6 → v7
- `docker/login-action` v3 → v4