### PR TITLE
Fix goreleaser docker build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,3 +40,6 @@ dockers_v2:
     tags:
     - "latest"
     - "{{ .Tag }}"
+    sbom: "none"
+    platforms:
+    - "linux/amd64"


### PR DESCRIPTION
Fix dockers_v2 configuration:
- Disable SBOM attestation (not supported by default Docker driver on CI)
- Set platform to linux/amd64 (Dockerfile copies pre-built binary)