### PR TITLE
Fix Docker image build in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,12 +34,7 @@ changelog:
       - "^docs:"
       - "^test:"
 
-dockers_v2:
-  - images:
-    - "ghcr.io/laenzlinger/setlist"
-    tags:
-    - "latest"
-    - "{{ .Tag }}"
-    sbom: "none"
-    platforms:
-    - "linux/amd64"
+dockers:
+  - image_templates:
+    - "ghcr.io/laenzlinger/setlist:latest"
+    - "ghcr.io/laenzlinger/setlist:{{ .Tag }}"


### PR DESCRIPTION
Revert from `dockers_v2` to `dockers` for Docker image builds.

`dockers_v2` uses `docker buildx` which doesn't work with the simple binary-copy Dockerfile pattern. The classic `dockers` approach correctly copies the built binary into the Docker context.

`dockers` is deprecated but still fully supported. When `dockers_v2` matures, we can migrate by switching to a multi-stage Dockerfile.