### PR TITLE
Auto-fit setlist font size to target page count

### DIFF
--- a/cmd/generate_setlist.go
+++ b/cmd/generate_setlist.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"html/template"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -30,6 +31,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+const defaultPages = 2
 
 //nolint:gochecknoglobals // cobra is designed like this
 var setlistCmd = &cobra.Command{
@@ -56,8 +59,12 @@ func init() {
 	err := viper.BindPFlag("setlist.include-columns", setlistCmd.Flags().Lookup("include-columns"))
 	cobra.CheckErr(err)
 
-	setlistCmd.Flags().StringP("font-size", "f", "24px", "set the main font size (css values are supported)")
+	setlistCmd.Flags().StringP("font-size", "f", "", "set the main font size (css values are supported)")
 	err = viper.BindPFlag("generate.list.font-size", setlistCmd.Flags().Lookup("font-size"))
+	cobra.CheckErr(err)
+
+	setlistCmd.Flags().IntP("pages", "p", defaultPages, "target number of pages (auto-fits font size)")
+	err = viper.BindPFlag("generate.list.pages", setlistCmd.Flags().Lookup("pages"))
 	cobra.CheckErr(err)
 }
 
@@ -80,18 +87,79 @@ func generateSetlist(gigName string) error {
 		Merge(gig).
 		Render()
 
-	data := tmpl.Data{
-		Title:    gig.Name,
-		FontSize: viper.GetString("generate.list.font-size"),
-		Margin:   "0cm",
-		Content:  template.HTML(content), //nolint: gosec // not a web application
+	outPath := filepath.Join(config.Target(), fmt.Sprintf("Set List %s.pdf", gig.Name))
+
+	fontSize := viper.GetString("generate.list.font-size")
+	if fontSize != "" {
+		return renderSetlist(content, gig.Name, fontSize, outPath)
 	}
 
-	filename, err := tmpl.CreateSetlist(&data)
+	targetPages := viper.GetInt("generate.list.pages")
+	return autoFitSetlist(content, gig.Name, targetPages, outPath)
+}
+
+func renderSetlist(content, title, fontSize, outPath string) error {
+	filename, err := createSetlistHTML(content, title, fontSize)
 	if err != nil {
 		return err
 	}
 	defer os.Remove(filename)
 
-	return convert.HTMLToPDF(filename, filepath.Join(config.Target(), fmt.Sprintf("Set List %s.pdf", gig.Name)))
+	return convert.HTMLToPDF(filename, outPath)
+}
+
+func autoFitSetlist(content, title string, targetPages int, outPath string) error {
+	const (
+		minFontSize = 10.0
+		maxFontSize = 60.0
+		precision   = 0.5
+	)
+
+	lo, hi := minFontSize, maxFontSize
+
+	for hi-lo > precision {
+		mid := (lo + hi) / 2 //nolint:mnd // binary search midpoint
+		fontSize := fmt.Sprintf("%.1fpx", mid)
+
+		pages, err := countPages(content, title, fontSize)
+		if err != nil {
+			return err
+		}
+
+		if pages <= targetPages {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+
+	fontSize := fmt.Sprintf("%.1fpx", lo)
+	log.Printf("auto-fit font size: %s for %d pages", fontSize, targetPages)
+
+	return renderSetlist(content, title, fontSize, outPath)
+}
+
+func countPages(content, title, fontSize string) (int, error) {
+	filename, err := createSetlistHTML(content, title, fontSize)
+	if err != nil {
+		return 0, err
+	}
+	defer os.Remove(filename)
+
+	pdfBytes, err := convert.HTMLToPDFBytes(filename)
+	if err != nil {
+		return 0, err
+	}
+
+	return convert.PageCount(pdfBytes)
+}
+
+func createSetlistHTML(content, title, fontSize string) (string, error) {
+	data := tmpl.Data{
+		Title:    title,
+		FontSize: fontSize,
+		Margin:   "0cm",
+		Content:  template.HTML(content), //nolint: gosec // not a web application
+	}
+	return tmpl.CreateSetlist(&data)
 }

--- a/docs/setlist_generate_list.md
+++ b/docs/setlist_generate_list.md
@@ -14,9 +14,10 @@ setlist generate list [flags]
 ### Options
 
 ```
-  -f, --font-size string          set the main font size (css values are supported) (default "24px")
+  -f, --font-size string          set the main font size (css values are supported)
   -h, --help                      help for list
   -i, --include-columns strings   defines the repertoire columns to include in the output (default [Title,Year,Description])
+  -p, --pages int                 target number of pages (auto-fits font size) (default 2)
 ```
 
 ### Options inherited from parent commands

--- a/internal/html/pdf/convert.go
+++ b/internal/html/pdf/convert.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -11,14 +12,24 @@ import (
 )
 
 func HTMLToPDF(in, out string) error {
-	wd, err := os.Getwd()
+	buf, err := HTMLToPDFBytes(in)
 	if err != nil {
 		return err
+	}
+	if err = os.WriteFile(out, buf, 0o600); err != nil {
+		return fmt.Errorf("failed to write PDF: %w", err)
+	}
+	return nil
+}
+
+func HTMLToPDFBytes(in string) ([]byte, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
 	}
 	url := fmt.Sprintf("file://%s/%s", wd, in)
 	opts := []chromedp.ExecAllocatorOption{}
 	if config.RunningInContainer() {
-		// when running inside a container, we don't use sandbox
 		opts = append(opts, chromedp.NoSandbox)
 	}
 
@@ -30,13 +41,33 @@ func HTMLToPDF(in, out string) error {
 
 	var buf []byte
 	if err = chromedp.Run(ctx, printToPDF(url, &buf)); err != nil {
-		return fmt.Errorf("failed to print PDF: %w", err)
+		return nil, fmt.Errorf("failed to print PDF: %w", err)
 	}
+	return buf, nil
+}
 
-	if err = os.WriteFile(out, buf, 0o600); err != nil {
-		return fmt.Errorf("failed to write PDF: %w", err)
+func PageCount(pdfBytes []byte) (int, error) {
+	// Count page objects by scanning for the /Type /Page pattern.
+	// This is a lightweight approach that avoids full PDF parsing,
+	// which can fail on Chrome-generated PDFs.
+	count := 0
+	needle := []byte("/Type /Page")
+	notLeaf := []byte("/Type /Pages")
+	for i := 0; i < len(pdfBytes); {
+		idx := bytes.Index(pdfBytes[i:], needle)
+		if idx < 0 {
+			break
+		}
+		pos := i + idx
+		// Skip /Type /Pages (non-leaf page tree nodes).
+		if pos+len(notLeaf) <= len(pdfBytes) && bytes.Equal(pdfBytes[pos:pos+len(notLeaf)], notLeaf) {
+			i = pos + len(notLeaf)
+			continue
+		}
+		count++
+		i = pos + len(needle)
 	}
-	return nil
+	return count, nil
 }
 
 const (


### PR DESCRIPTION
Closes #52

## Changes

- New `--pages` flag (default 2) on `generate list` command
- Auto-fits font size using binary search (10px–60px, 0.5px precision, ~7 iterations)
- Maximizes font size to use as much of the page real estate as possible
- `--font-size` flag overrides auto-fit when explicitly set
- Refactored `convert` package: extracted `HTMLToPDFBytes()` and `PageCount()`

## Usage

```bash
# Auto-fit to 2 pages (default)
setlist generate list

# Auto-fit to 3 pages
setlist generate list --pages 3

# Override with explicit font size (no auto-fit)
setlist generate list --font-size 40px
```

## Verified
- Build ✅
- Tests ✅
- Lint ✅ (0 issues)