### PR TITLE
Use mise exec in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,18 +15,18 @@ repos:
     hooks:
       - id: go-build
         name: go build
-        entry: go build ./...
+        entry: mise exec -- go build ./...
         language: system
         pass_filenames: false
 
       - id: go-test
         name: go test
-        entry: go test ./...
+        entry: mise exec -- go test ./...
         language: system
         pass_filenames: false
 
       - id: golangci-lint
         name: golangci-lint
-        entry: golangci-lint run
+        entry: mise exec -- golangci-lint run
         language: system
         pass_filenames: false


### PR DESCRIPTION
Ensures golangci-lint and other tools are available via mise when running pre-commit hooks locally.